### PR TITLE
Add website option to social links

### DIFF
--- a/_data/sponsors.yml
+++ b/_data/sponsors.yml
@@ -67,6 +67,8 @@
   site: /sponsorships
   image: /images/speakers/sponsor.jpg
   retina: 1
+  social:
+    website: /sponsorships
 
 # - ftf:
 #   name: From The Future

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -41,6 +41,11 @@
                   <a href="https://github.com/{{ sponsor.social.github }}" target="_blank"><i class="icon fa fa-github"></i></a>
                 </li>
               {% endif %}
+              {% if sponsor.social.website %}
+                <li>
+                  <a href="{{ sponsor.social.website }}"><i class="icon fa fa-link"></i></a>
+                </li>
+              {% endif %}
             </ul>
             {% endif %}
           </div>


### PR DESCRIPTION
The problem is that the last grid option doesn't have any links, making it slightly shorter than the others. This solution gives all sponsors a new option for a website, and let's us add a link to the "Sponsor us" option.